### PR TITLE
CTED-1216 fixing issue when dont have replies

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -726,6 +726,7 @@ HTML;
                 hsuforum_mark_post_read($USER->id, $parent, $forum->id);
             }
         }
+        $output  = "<h5 role='heading' aria-level='5'>".hsuforum_xreplies($count)."</h5>";
         if (!empty($count)) {
             $output = "<ol class='hsuforum-thread-replies-list'>".$items."</ol>";
         }


### PR DESCRIPTION
There was a warning when the post dont have replies 

<img width="720" alt="Screen Shot 2020-07-15 at 8 42 36" src="https://user-images.githubusercontent.com/64023605/87570975-fec1f080-c68e-11ea-9ed2-54448023a953.png">

With the fix we just put the counter with 0. 

<img width="990" alt="Screen Shot 2020-07-15 at 11 18 21" src="https://user-images.githubusercontent.com/64023605/87571094-21540980-c68f-11ea-9087-06bcab79174a.png">
