### PR TITLE
ACADEMIC-15119 | Update hsuforum_cm_info_view to avoid recursion

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -7316,10 +7316,7 @@ function hsuforum_cm_info_view(cm_info $cm) {
         $out .= '</a>';
     }
 
-    if(property_exists($cm, 'content') && strlen($cm->content) > 0) {
-        $out = $cm->content . $out;
-    }
-    $cm->set_content($out); // append the unreadpost section to existing content
+    $cm->set_after_link($out); // append the unreadpost section to existing content
 }
 
 /**


### PR DESCRIPTION
Hi,

If a plugin like local_annoto and mod_hsuforum are used at the same time in a PHP 7.4+ environment, there will be a PHP exception with this message: "Exception - Cannot access private property cm_info::$content". 

If set_after_link() is used it will perform the same action as an append to content but without the recursion problem.